### PR TITLE
Enhance/conformu

### DIFF
--- a/src/alpaca_simulators/api/camera.py
+++ b/src/alpaca_simulators/api/camera.py
@@ -29,9 +29,23 @@ router = APIRouter()
 image_cache = {}
 
 
-def make_cache_key(ra, dec, duration, light, focus, sunlight, tracking_ra_rate, tracking_dec_rate):
+def make_cache_key(
+    ra,
+    dec,
+    duration,
+    light,
+    focus,
+    sunlight,
+    tracking_ra_rate,
+    tracking_dec_rate,
+    numx,
+    numy,
+    binx,
+    biny,
+):
     return (
-        f"{ra}_{dec}_{duration}_{light}_{focus}_{sunlight}_{tracking_ra_rate}_{tracking_dec_rate}"
+        f"{ra}_{dec}_{duration}_{light}_{focus}_{sunlight}_"
+        f"{tracking_ra_rate}_{tracking_dec_rate}_{numx}x{numy}_b{binx}x{biny}"
     )
 
 
@@ -174,6 +188,10 @@ async def exposure_task(device_number: int, duration: float, light: bool):
             sunlight=sunlight,
             tracking_ra_rate=tracking_ra_rate,
             tracking_dec_rate=tracking_dec_rate,
+            numx=cam_state.get("numx"),
+            numy=cam_state.get("numy"),
+            binx=cam_state.get("binx", 1),
+            biny=cam_state.get("biny", 1),
         )
         if key in image_cache:
             print(f"Using cached image for key: {key}")
@@ -293,14 +311,34 @@ def start_exposure(
     state = get_device_state("camera", device_number)
     if Duration < state.get("exposuremin", 0.001):
         raise AlpacaError(
-            0x402,
+            0x401,
             f"Exposure duration too short (minimum: {state.get('exposuremin', 0.001)}s)",
         )
 
     if Duration > state.get("exposuremax", 3600.0):
         raise AlpacaError(
-            0x402,
+            0x401,
             f"Exposure duration too long (maximum: {state.get('exposuremax', 3600.0)}s)",
+        )
+
+    # Validate the subframe in binned pixels (NumX/NumY/StartX/StartY are binned).
+    binx = state.get("binx", 1)
+    biny = state.get("biny", 1)
+    max_binned_x = state.get("cameraxsize", 1024) // binx
+    max_binned_y = state.get("cameraysize", 1024) // biny
+    numx = state.get("numx", max_binned_x)
+    numy = state.get("numy", max_binned_y)
+    startx = state.get("startx", 0)
+    starty = state.get("starty", 0)
+    if numx < 1 or startx < 0 or startx + numx > max_binned_x:
+        raise AlpacaError(
+            0x401,
+            f"Subframe X out of range: StartX={startx}, NumX={numx}, max={max_binned_x}",
+        )
+    if numy < 1 or starty < 0 or starty + numy > max_binned_y:
+        raise AlpacaError(
+            0x401,
+            f"Subframe Y out of range: StartY={starty}, NumY={numy}, max={max_binned_y}",
         )
 
     # Start exposure task
@@ -697,6 +735,8 @@ def get_lastexposureduration(
 ):
     validate_device("camera", device_number)
     state = get_device_state("camera", device_number)
+    if not state.get("exposure_start_time"):
+        raise AlpacaError(0x40B, "No exposure has been taken")
     return DoubleResponse(
         Value=state.get("exposure_duration", 0.0),
         ClientTransactionID=ClientTransactionID,
@@ -710,8 +750,11 @@ def get_lastexposurestarttime(
 ):
     validate_device("camera", device_number)
     state = get_device_state("camera", device_number)
+    start_time = state.get("exposure_start_time")
+    if not start_time:
+        raise AlpacaError(0x40B, "No exposure has been taken")
     return StringResponse(
-        Value=str(state.get("exposure_start_time", "")),
+        Value=str(start_time),
         ClientTransactionID=ClientTransactionID,
         ServerTransactionID=get_server_transaction_id(),
     )
@@ -825,7 +868,13 @@ def set_ccdtemperature(
 
     state = get_device_state("camera", device_number)
     if not state.get("cansetccdtemperature", True):
-        raise AlpacaError(0x401, "Camera does not support temperature control")
+        raise AlpacaError(0x400, "Camera does not support temperature control")
+
+    if SetCCDTemperature <= -273.15 or SetCCDTemperature >= 100.0:
+        raise AlpacaError(
+            0x401,
+            f"SetCCDTemperature {SetCCDTemperature} out of range (-273.15, 100.0)",
+        )
 
     update_device_state("camera", device_number, {"setccdtemperature": SetCCDTemperature})
 
@@ -884,12 +933,15 @@ def get_coolerpower(device_number: int = Path(..., ge=0), ClientTransactionID: i
 
 
 # Gain control
-@router.get("/camera/{device_number}/gain", response_model=DoubleResponse)
+# This camera operates in "Gains" list mode: Gain returns the integer index into
+# the Gains list, and GainMin/GainMax must return PropertyNotImplemented because
+# the two modes (Gains list vs. numeric min/max) are mutually exclusive in ASCOM.
+@router.get("/camera/{device_number}/gain", response_model=IntResponse)
 def get_gain(device_number: int = Path(..., ge=0), ClientTransactionID: int = Query(0)):
     validate_device("camera", device_number)
     state = get_device_state("camera", device_number)
-    return DoubleResponse(
-        Value=state.get("gain", 1.0),
+    return IntResponse(
+        Value=int(state.get("gain", 0)),
         ClientTransactionID=ClientTransactionID,
         ServerTransactionID=get_server_transaction_id(),
     )
@@ -898,21 +950,15 @@ def get_gain(device_number: int = Path(..., ge=0), ClientTransactionID: int = Qu
 @router.put("/camera/{device_number}/gain", response_model=AlpacaResponse)
 def set_gain(
     device_number: int = Path(..., ge=0),
-    Gain: float = Form(...),
+    Gain: int = Form(...),
     ClientTransactionID: int = Form(0),
 ):
     validate_device("camera", device_number)
-    # state = get_device_state("camera", device_number)
-
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
 
     state = get_device_state("camera", device_number)
-    min_gain = state.get("gainmin", 0.1)
-    max_gain = state.get("gainmax", 10.0)
-
-    if Gain < min_gain or Gain > max_gain:
-        raise AlpacaError(0x402, f"Gain out of range ({min_gain} to {max_gain})")
+    gains = state.get("gains", [])
+    if Gain < 0 or Gain >= len(gains):
+        raise AlpacaError(0x401, f"Gain index out of range (0 to {len(gains) - 1})")
 
     update_device_state("camera", device_number, {"gain": Gain})
 
@@ -922,26 +968,16 @@ def set_gain(
     )
 
 
-@router.get("/camera/{device_number}/gainmax", response_model=DoubleResponse)
+@router.get("/camera/{device_number}/gainmax", response_model=IntResponse)
 def get_gainmax(device_number: int = Path(..., ge=0), ClientTransactionID: int = Query(0)):
     validate_device("camera", device_number)
-    state = get_device_state("camera", device_number)
-    return DoubleResponse(
-        Value=state.get("gainmax", 10.0),
-        ClientTransactionID=ClientTransactionID,
-        ServerTransactionID=get_server_transaction_id(),
-    )
+    raise AlpacaError(0x400, "GainMax not implemented when Gains list is provided")
 
 
-@router.get("/camera/{device_number}/gainmin", response_model=DoubleResponse)
+@router.get("/camera/{device_number}/gainmin", response_model=IntResponse)
 def get_gainmin(device_number: int = Path(..., ge=0), ClientTransactionID: int = Query(0)):
     validate_device("camera", device_number)
-    state = get_device_state("camera", device_number)
-    return DoubleResponse(
-        Value=state.get("gainmin", 0.1),
-        ClientTransactionID=ClientTransactionID,
-        ServerTransactionID=get_server_transaction_id(),
-    )
+    raise AlpacaError(0x400, "GainMin not implemented when Gains list is provided")
 
 
 @router.get("/camera/{device_number}/gains", response_model=StringArrayResponse)
@@ -956,12 +992,15 @@ def get_gains(device_number: int = Path(..., ge=0), ClientTransactionID: int = Q
 
 
 # Offset control
-@router.get("/camera/{device_number}/offset", response_model=DoubleResponse)
+# This camera operates in "Offsets" list mode: Offset returns the integer index
+# into the Offsets list, and OffsetMin/OffsetMax must return PropertyNotImplemented
+# because the two modes are mutually exclusive in ASCOM.
+@router.get("/camera/{device_number}/offset", response_model=IntResponse)
 def get_offset(device_number: int = Path(..., ge=0), ClientTransactionID: int = Query(0)):
     validate_device("camera", device_number)
     state = get_device_state("camera", device_number)
-    return DoubleResponse(
-        Value=state.get("offset", 0.0),
+    return IntResponse(
+        Value=int(state.get("offset", 0)),
         ClientTransactionID=ClientTransactionID,
         ServerTransactionID=get_server_transaction_id(),
     )
@@ -970,21 +1009,15 @@ def get_offset(device_number: int = Path(..., ge=0), ClientTransactionID: int = 
 @router.put("/camera/{device_number}/offset", response_model=AlpacaResponse)
 def set_offset(
     device_number: int = Path(..., ge=0),
-    Offset: float = Form(...),
+    Offset: int = Form(...),
     ClientTransactionID: int = Form(0),
 ):
     validate_device("camera", device_number)
-    # state = get_device_state("camera", device_number)
-
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
 
     state = get_device_state("camera", device_number)
-    min_offset = state.get("offsetmin", -1000.0)
-    max_offset = state.get("offsetmax", 1000.0)
-
-    if Offset < min_offset or Offset > max_offset:
-        raise AlpacaError(0x402, f"Offset out of range ({min_offset} to {max_offset})")
+    offsets = state.get("offsets", [])
+    if Offset < 0 or Offset >= len(offsets):
+        raise AlpacaError(0x401, f"Offset index out of range (0 to {len(offsets) - 1})")
 
     update_device_state("camera", device_number, {"offset": Offset})
 
@@ -994,26 +1027,16 @@ def set_offset(
     )
 
 
-@router.get("/camera/{device_number}/offsetmax", response_model=DoubleResponse)
+@router.get("/camera/{device_number}/offsetmax", response_model=IntResponse)
 def get_offsetmax(device_number: int = Path(..., ge=0), ClientTransactionID: int = Query(0)):
     validate_device("camera", device_number)
-    state = get_device_state("camera", device_number)
-    return DoubleResponse(
-        Value=state.get("offsetmax", 1000.0),
-        ClientTransactionID=ClientTransactionID,
-        ServerTransactionID=get_server_transaction_id(),
-    )
+    raise AlpacaError(0x400, "OffsetMax not implemented when Offsets list is provided")
 
 
-@router.get("/camera/{device_number}/offsetmin", response_model=DoubleResponse)
+@router.get("/camera/{device_number}/offsetmin", response_model=IntResponse)
 def get_offsetmin(device_number: int = Path(..., ge=0), ClientTransactionID: int = Query(0)):
     validate_device("camera", device_number)
-    state = get_device_state("camera", device_number)
-    return DoubleResponse(
-        Value=state.get("offsetmin", -1000.0),
-        ClientTransactionID=ClientTransactionID,
-        ServerTransactionID=get_server_transaction_id(),
-    )
+    raise AlpacaError(0x400, "OffsetMin not implemented when Offsets list is provided")
 
 
 @router.get("/camera/{device_number}/offsets", response_model=StringArrayResponse)
@@ -1047,17 +1070,13 @@ def set_numx(
     ClientTransactionID: int = Form(0),
 ):
     validate_device("camera", device_number)
-    state = get_device_state("camera", device_number)
 
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
-
-    state = get_device_state("camera", device_number)
-    max_x = state.get("cameraxsize", 1024)
-    startx = state.get("startx", 0)
-
-    if NumX < 1 or (startx + NumX) > max_x:
-        raise AlpacaError(0x402, f"NumX out of range (1 to {max_x - startx})")
+    # Permissive setter: the combined subframe geometry is validated in
+    # StartExposure. Only obvious garbage is rejected here. ConformU expects to
+    # be able to write out-of-range values to test that StartExposure rejects
+    # them.
+    if NumX < 1:
+        raise AlpacaError(0x401, f"NumX must be >= 1, got {NumX}")
 
     update_device_state("camera", device_number, {"numx": NumX})
 
@@ -1086,17 +1105,9 @@ def set_numy(
     ClientTransactionID: int = Form(0),
 ):
     validate_device("camera", device_number)
-    state = get_device_state("camera", device_number)
 
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
-
-    state = get_device_state("camera", device_number)
-    max_y = state.get("cameraysize", 1024)
-    starty = state.get("starty", 0)
-
-    if NumY < 1 or (starty + NumY) > max_y:
-        raise AlpacaError(0x402, f"NumY out of range (1 to {max_y - starty})")
+    if NumY < 1:
+        raise AlpacaError(0x401, f"NumY must be >= 1, got {NumY}")
 
     update_device_state("camera", device_number, {"numy": NumY})
 
@@ -1124,17 +1135,9 @@ def set_startx(
     ClientTransactionID: int = Form(0),
 ):
     validate_device("camera", device_number)
-    state = get_device_state("camera", device_number)
 
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
-
-    state = get_device_state("camera", device_number)
-    max_x = state.get("cameraxsize", 1024)
-    numx = state.get("numx", max_x)
-
-    if StartX < 0 or (StartX + numx) > max_x:
-        raise AlpacaError(0x402, f"StartX out of range (0 to {max_x - numx})")
+    if StartX < 0:
+        raise AlpacaError(0x401, f"StartX must be >= 0, got {StartX}")
 
     update_device_state("camera", device_number, {"startx": StartX})
 
@@ -1162,17 +1165,9 @@ def set_starty(
     ClientTransactionID: int = Form(0),
 ):
     validate_device("camera", device_number)
-    state = get_device_state("camera", device_number)
 
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
-
-    state = get_device_state("camera", device_number)
-    max_y = state.get("cameraysize", 1024)
-    numy = state.get("numy", max_y)
-
-    if StartY < 0 or (StartY + numy) > max_y:
-        raise AlpacaError(0x402, f"StartY out of range (0 to {max_y - numy})")
+    if StartY < 0:
+        raise AlpacaError(0x401, f"StartY must be >= 0, got {StartY}")
 
     update_device_state("camera", device_number, {"starty": StartY})
 
@@ -1187,6 +1182,8 @@ def set_starty(
 def get_fastreadout(device_number: int = Path(..., ge=0), ClientTransactionID: int = Query(0)):
     validate_device("camera", device_number)
     state = get_device_state("camera", device_number)
+    if not state.get("canfastreadout", False):
+        raise AlpacaError(0x400, "Camera does not support fast readout mode")
     return BoolResponse(
         Value=state.get("fastreadout", False),
         ClientTransactionID=ClientTransactionID,
@@ -1201,14 +1198,10 @@ def set_fastreadout(
     ClientTransactionID: int = Form(0),
 ):
     validate_device("camera", device_number)
-    # state = get_device_state("camera", device_number)
-
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
 
     state = get_device_state("camera", device_number)
-    if not state.get("canfastreadout", True):
-        raise AlpacaError(0x401, "Camera does not support fast readout mode")
+    if not state.get("canfastreadout", False):
+        raise AlpacaError(0x400, "Camera does not support fast readout mode")
 
     update_device_state("camera", device_number, {"fastreadout": FastReadout})
 
@@ -1246,22 +1239,27 @@ def get_ispulseguiding(device_number: int = Path(..., ge=0), ClientTransactionID
     )
 
 
+async def _pulseguide_task(device_number: int, duration_ms: int):
+    """Hold IsPulseGuiding=True for the requested duration, then clear it."""
+    try:
+        await asyncio.sleep(duration_ms / 1000.0)
+    finally:
+        update_device_state("camera", device_number, {"ispulseguiding": False})
+
+
 @router.put("/camera/{device_number}/pulseguide", response_model=AlpacaResponse)
 def pulseguide(
+    background_tasks: BackgroundTasks,
     device_number: int = Path(..., ge=0),
     Direction: int = Form(...),
     Duration: int = Form(...),
     ClientTransactionID: int = Form(0),
 ):
     validate_device("camera", device_number)
-    # state = get_device_state("camera", device_number)
-
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
 
     state = get_device_state("camera", device_number)
     if not state.get("canpulseguide", True):
-        raise AlpacaError(0x401, "Camera does not support pulse guiding")
+        raise AlpacaError(0x400, "Camera does not support pulse guiding")
 
     if Direction not in [
         GuideDirections.NORTH,
@@ -1269,17 +1267,13 @@ def pulseguide(
         GuideDirections.EAST,
         GuideDirections.WEST,
     ]:
-        raise AlpacaError(0x402, "Invalid guide direction")
+        raise AlpacaError(0x401, "Invalid guide direction")
 
     if Duration < 0:
-        raise AlpacaError(0x402, "Duration must be positive")
+        raise AlpacaError(0x401, "Duration must be positive")
 
-    # Simulate pulse guiding
     update_device_state("camera", device_number, {"ispulseguiding": True})
-
-    # In a real implementation, this would start a timer
-    # For simulation, we immediately stop pulse guiding
-    update_device_state("camera", device_number, {"ispulseguiding": False})
+    background_tasks.add_task(_pulseguide_task, device_number, Duration)
 
     return AlpacaResponse(
         ClientTransactionID=ClientTransactionID,
@@ -1288,17 +1282,14 @@ def pulseguide(
 
 
 # Sub-exposure duration
+# This simulator does not support sub-exposure stacking, so both get and set
+# return PropertyNotImplemented per ASCOM convention.
 @router.get("/camera/{device_number}/subexposureduration", response_model=DoubleResponse)
 def get_subexposureduration(
     device_number: int = Path(..., ge=0), ClientTransactionID: int = Query(0)
 ):
     validate_device("camera", device_number)
-    state = get_device_state("camera", device_number)
-    return DoubleResponse(
-        Value=state.get("subexposureduration", 1.0),
-        ClientTransactionID=ClientTransactionID,
-        ServerTransactionID=get_server_transaction_id(),
-    )
+    raise AlpacaError(0x400, "SubExposureDuration is not implemented")
 
 
 @router.put("/camera/{device_number}/subexposureduration", response_model=AlpacaResponse)
@@ -1308,20 +1299,7 @@ def set_subexposureduration(
     ClientTransactionID: int = Form(0),
 ):
     validate_device("camera", device_number)
-    # state = get_device_state("camera", device_number)
-
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
-
-    if SubExposureDuration <= 0:
-        raise AlpacaError(0x402, "Sub-exposure duration must be positive")
-
-    update_device_state("camera", device_number, {"subexposureduration": SubExposureDuration})
-
-    return AlpacaResponse(
-        ClientTransactionID=ClientTransactionID,
-        ServerTransactionID=get_server_transaction_id(),
-    )
+    raise AlpacaError(0x400, "SubExposureDuration is not implemented")
 
 
 # Deprecated endpoint for compatibility

--- a/src/alpaca_simulators/api/covercalibrator.py
+++ b/src/alpaca_simulators/api/covercalibrator.py
@@ -15,10 +15,17 @@ from alpaca_simulators.state import (
 router = APIRouter()
 
 
+def _require_calibrator(state):
+    """Raise PropertyNotImplemented when no calibrator is present."""
+    if state.get("calibratorstate", CalibratorStatus.NOT_PRESENT) == CalibratorStatus.NOT_PRESENT:
+        raise AlpacaError(0x400, "Calibrator is not present on this device")
+
+
 @router.get("/covercalibrator/{device_number}/brightness", response_model=IntResponse)
 def get_brightness(device_number: int = Path(..., ge=0), ClientTransactionID: int = Query(0)):
     validate_device("covercalibrator", device_number)
     state = get_device_state("covercalibrator", device_number)
+    _require_calibrator(state)
     return IntResponse(
         Value=state.get("brightness", 0),
         ClientTransactionID=ClientTransactionID,
@@ -76,6 +83,7 @@ def get_coverstate(device_number: int = Path(..., ge=0), ClientTransactionID: in
 def get_maxbrightness(device_number: int = Path(..., ge=0), ClientTransactionID: int = Query(0)):
     validate_device("covercalibrator", device_number)
     state = get_device_state("covercalibrator", device_number)
+    _require_calibrator(state)
     return IntResponse(
         Value=state.get("maxbrightness", 255),
         ClientTransactionID=ClientTransactionID,
@@ -86,10 +94,8 @@ def get_maxbrightness(device_number: int = Path(..., ge=0), ClientTransactionID:
 @router.put("/covercalibrator/{device_number}/calibratoroff", response_model=AlpacaResponse)
 def calibratoroff(device_number: int = Path(..., ge=0), ClientTransactionID: int = Form(0)):
     validate_device("covercalibrator", device_number)
-    # state = get_device_state("covercalibrator", device_number)
-
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
+    state = get_device_state("covercalibrator", device_number)
+    _require_calibrator(state)
 
     update_device_state(
         "covercalibrator",
@@ -114,15 +120,12 @@ def calibratoron(
     ClientTransactionID: int = Form(0),
 ):
     validate_device("covercalibrator", device_number)
-    # state = get_device_state("covercalibrator", device_number)
     state = get_device_state("covercalibrator", device_number)
-
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
+    _require_calibrator(state)
 
     max_brightness = state.get("maxbrightness", 255)
     if Brightness < 0 or Brightness > max_brightness:
-        raise AlpacaError(0x402, f"Brightness out of range (0-{max_brightness})")
+        raise AlpacaError(0x401, f"Brightness out of range (0-{max_brightness})")
 
     update_device_state(
         "covercalibrator",
@@ -163,17 +166,9 @@ def closecover(device_number: int = Path(..., ge=0), ClientTransactionID: int = 
 @router.put("/covercalibrator/{device_number}/haltcover", response_model=AlpacaResponse)
 def haltcover(device_number: int = Path(..., ge=0), ClientTransactionID: int = Form(0)):
     validate_device("covercalibrator", device_number)
-    # state = get_device_state("covercalibrator", device_number)
-
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
-
-    update_device_state("covercalibrator", device_number, {"covermoving": False})
-
-    return AlpacaResponse(
-        ClientTransactionID=ClientTransactionID,
-        ServerTransactionID=get_server_transaction_id(),
-    )
+    # OpenCover and CloseCover complete synchronously in this simulator, so per
+    # ASCOM convention HaltCover must report itself as not implemented.
+    raise AlpacaError(0x400, "HaltCover is not implemented for a synchronous cover")
 
 
 @router.put("/covercalibrator/{device_number}/opencover", response_model=AlpacaResponse)

--- a/src/alpaca_simulators/api/dome.py
+++ b/src/alpaca_simulators/api/dome.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Form, Path, Query
+import asyncio
+
+from fastapi import APIRouter, BackgroundTasks, Form, Path, Query
 
 from alpaca_simulators.api.common import AlpacaError, validate_device
 from alpaca_simulators.state import (
@@ -13,6 +15,34 @@ from alpaca_simulators.state import (
 )
 
 router = APIRouter()
+
+# How long a simulated dome slew/find-home/park takes. Kept above ConformU's
+# 3-second "is it slewing?" check so AbortSlew tests can observe Slewing=True.
+_SLEW_DURATION_SECONDS = 4.0
+
+
+async def _slew_task(device_number: int, axis: str, target: float, gen: int):
+    """Hold Slewing=True for the slew duration, then apply target unless an
+    abort or newer slew superseded this one (tracked by ``slew_gen``)."""
+    await asyncio.sleep(_SLEW_DURATION_SECONDS)
+    state = get_device_state("dome", device_number)
+    if state.get("slew_gen") != gen or not state.get("slewing", False):
+        # Aborted, or a newer slew took over — leave state alone.
+        return
+    update = {axis: target, "slewing": False, "atpark": False, "athome": False}
+    update_device_state("dome", device_number, update)
+
+
+def _begin_slew(device_number: int, axis: str, target: float, background_tasks: BackgroundTasks):
+    """Mark the dome as slewing, bump the generation, and schedule completion."""
+    state = get_device_state("dome", device_number)
+    new_gen = state.get("slew_gen", 0) + 1
+    update_device_state(
+        "dome",
+        device_number,
+        {"slewing": True, "slew_gen": new_gen, "athome": False, "atpark": False},
+    )
+    background_tasks.add_task(_slew_task, device_number, axis, target, new_gen)
 
 
 @router.get("/dome/{device_number}/altitude", response_model=DoubleResponse)
@@ -210,12 +240,14 @@ def get_slewing(device_number: int = Path(..., ge=0), ClientTransactionID: int =
 @router.put("/dome/{device_number}/abortslew", response_model=AlpacaResponse)
 def abortslew(device_number: int = Path(..., ge=0), ClientTransactionID: int = Form(0)):
     validate_device("dome", device_number)
-    # state = get_device_state("dome", device_number)
 
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
-
-    update_device_state("dome", device_number, {"slewing": False})
+    # Bump slew_gen so any in-flight slew task no-ops when it wakes up.
+    state = get_device_state("dome", device_number)
+    update_device_state(
+        "dome",
+        device_number,
+        {"slewing": False, "slew_gen": state.get("slew_gen", 0) + 1},
+    )
 
     return AlpacaResponse(
         ClientTransactionID=ClientTransactionID,
@@ -314,28 +346,17 @@ def setpark(device_number: int = Path(..., ge=0), ClientTransactionID: int = For
 
 @router.put("/dome/{device_number}/slewtoaltitude", response_model=AlpacaResponse)
 def slewtoaltitude(
+    background_tasks: BackgroundTasks,
     device_number: int = Path(..., ge=0),
     Altitude: float = Form(...),
     ClientTransactionID: int = Form(0),
 ):
     validate_device("dome", device_number)
-    # state = get_device_state("dome", device_number)
-
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
 
     if Altitude < 0.0 or Altitude > 90.0:
-        raise AlpacaError(0x402, "Altitude must be between 0 and 90 degrees")
+        raise AlpacaError(0x401, "Altitude must be between 0 and 90 degrees")
 
-    update_device_state(
-        "dome",
-        device_number,
-        {
-            "altitude": Altitude,
-            "slewing": False,  # Simplified - immediate slew
-            "atpark": False,
-        },
-    )
+    _begin_slew(device_number, "altitude", Altitude, background_tasks)
 
     return AlpacaResponse(
         ClientTransactionID=ClientTransactionID,
@@ -345,28 +366,17 @@ def slewtoaltitude(
 
 @router.put("/dome/{device_number}/slewtoazimuth", response_model=AlpacaResponse)
 def slewtoazimuth(
+    background_tasks: BackgroundTasks,
     device_number: int = Path(..., ge=0),
     Azimuth: float = Form(...),
     ClientTransactionID: int = Form(0),
 ):
     validate_device("dome", device_number)
-    # state = get_device_state("dome", device_number)
-
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
 
     if Azimuth < 0.0 or Azimuth >= 360.0:
-        raise AlpacaError(0x402, "Azimuth must be between 0 and 360 degrees")
+        raise AlpacaError(0x401, "Azimuth must be between 0 and 360 degrees")
 
-    update_device_state(
-        "dome",
-        device_number,
-        {
-            "azimuth": Azimuth,
-            "slewing": False,  # Simplified - immediate slew
-            "atpark": False,
-        },
-    )
+    _begin_slew(device_number, "azimuth", Azimuth, background_tasks)
 
     return AlpacaResponse(
         ClientTransactionID=ClientTransactionID,
@@ -381,14 +391,11 @@ def synctoazimuth(
     ClientTransactionID: int = Form(0),
 ):
     validate_device("dome", device_number)
-    # state = get_device_state("dome", device_number)
-
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
 
     if Azimuth < 0.0 or Azimuth >= 360.0:
-        raise AlpacaError(0x402, "Azimuth must be between 0 and 360 degrees")
+        raise AlpacaError(0x401, "Azimuth must be between 0 and 360 degrees")
 
+    # Sync is instantaneous: snap azimuth to the requested value without slewing.
     update_device_state("dome", device_number, {"azimuth": Azimuth})
 
     return AlpacaResponse(

--- a/src/alpaca_simulators/api/filterwheel.py
+++ b/src/alpaca_simulators/api/filterwheel.py
@@ -54,16 +54,12 @@ def set_position(
     ClientTransactionID: int = Form(0),
 ):
     validate_device("filterwheel", device_number)
-    # state = get_device_state("filterwheel", device_number)
-
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
 
     state = get_device_state("filterwheel", device_number)
     max_position = len(state.get("names", [])) - 1
 
     if Position < 0 or Position > max_position:
-        raise AlpacaError(0x402, f"Position out of range (0-{max_position})")
+        raise AlpacaError(0x401, f"Position out of range (0-{max_position})")
 
     update_device_state("filterwheel", device_number, {"position": Position})
 

--- a/src/alpaca_simulators/api/focuser.py
+++ b/src/alpaca_simulators/api/focuser.py
@@ -162,24 +162,20 @@ def move(
     ClientTransactionID: int = Form(0),
 ):
     validate_device("focuser", device_number)
-    # state = get_device_state("focuser", device_number)
-
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
 
     state = get_device_state("focuser", device_number)
     max_step = state.get("maxstep", 100000)
 
-    if Position < 0 or Position > max_step:
-        raise AlpacaError(0x402, f"Position out of range (0-{max_step})")
+    # Per ASCOM, out-of-range Move targets are clamped silently to [0, MaxStep]
+    # rather than raising an exception.
+    target = max(0, min(Position, max_step))
 
-    # Simulate movement
     update_device_state(
         "focuser",
         device_number,
         {
-            "position": Position,
-            "ismoving": False,  # For simulator, movement is instantaneous
+            "position": target,
+            "ismoving": False,  # Simulator: movement is instantaneous.
         },
     )
 

--- a/src/alpaca_simulators/api/observingconditions.py
+++ b/src/alpaca_simulators/api/observingconditions.py
@@ -31,13 +31,11 @@ def set_averageperiod(
     ClientTransactionID: int = Form(0),
 ):
     validate_device("observingconditions", device_number)
-    # state = get_device_state("observingconditions", device_number)
 
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
-
-    if AveragePeriod <= 0:
-        raise AlpacaError(0x402, "Average period must be positive")
+    # Per ASCOM, AveragePeriod must be non-negative. A value of 0 means
+    # "no averaging" and is a valid setting.
+    if AveragePeriod < 0:
+        raise AlpacaError(0x401, "Average period must be non-negative")
 
     update_device_state("observingconditions", device_number, {"averageperiod": AveragePeriod})
 
@@ -71,7 +69,7 @@ def set_cloudcover(
     # raise AlpacaError(0x407, "Device is not connected")
 
     if CloudCover < 0.0 or CloudCover > 1.0:
-        raise AlpacaError(0x402, "Cloud cover must be between 0.0 and 1.0")
+        raise AlpacaError(0x401, "Cloud cover must be between 0.0 and 1.0")
 
     update_device_state("observingconditions", device_number, {"cloudcover": CloudCover})
 
@@ -105,7 +103,7 @@ def set_dewpoint(
     # raise AlpacaError(0x407, "Device is not connected")
 
     if DewPoint < -50.0 or DewPoint > 50.0:
-        raise AlpacaError(0x402, "Dew point must be between -50.0°C and 50.0°C")
+        raise AlpacaError(0x401, "Dew point must be between -50.0°C and 50.0°C")
 
     update_device_state("observingconditions", device_number, {"dewpoint": DewPoint})
 
@@ -139,7 +137,7 @@ def set_humidity(
     # raise AlpacaError(0x407, "Device is not connected")
 
     if Humidity < 0.0 or Humidity > 100.0:
-        raise AlpacaError(0x402, "Humidity must be between 0.0% and 100.0%")
+        raise AlpacaError(0x401, "Humidity must be between 0.0% and 100.0%")
 
     update_device_state("observingconditions", device_number, {"humidity": Humidity})
 
@@ -173,7 +171,7 @@ def set_pressure(
     # raise AlpacaError(0x407, "Device is not connected")
 
     if Pressure < 800.0 or Pressure > 1200.0:
-        raise AlpacaError(0x402, "Pressure must be between 800.0 and 1200.0 hPa")
+        raise AlpacaError(0x401, "Pressure must be between 800.0 and 1200.0 hPa")
 
     update_device_state("observingconditions", device_number, {"pressure": Pressure})
 
@@ -207,7 +205,7 @@ def set_rainrate(
     # raise AlpacaError(0x407, "Device is not connected")
 
     if RainRate < 0.0 or RainRate > 100.0:
-        raise AlpacaError(0x402, "Rain rate must be between 0.0 and 100.0 mm/hr")
+        raise AlpacaError(0x401, "Rain rate must be between 0.0 and 100.0 mm/hr")
 
     update_device_state("observingconditions", device_number, {"rainrate": RainRate})
 
@@ -277,7 +275,7 @@ def set_skyquality(
     # raise AlpacaError(0x407, "Device is not connected")
 
     if SkyQuality < 15.0 or SkyQuality > 25.0:
-        raise AlpacaError(0x402, "Sky quality must be between 15.0 and 25.0 mag/arcsec²")
+        raise AlpacaError(0x401, "Sky quality must be between 15.0 and 25.0 mag/arcsec²")
 
     update_device_state("observingconditions", device_number, {"skyquality": SkyQuality})
 
@@ -342,7 +340,7 @@ def set_starfwhm(
     # raise AlpacaError(0x407, "Device is not connected")
 
     if StarFWHM < 0.5 or StarFWHM > 10.0:
-        raise AlpacaError(0x402, "Star FWHM must be between 0.5 and 10.0 arcseconds")
+        raise AlpacaError(0x401, "Star FWHM must be between 0.5 and 10.0 arcseconds")
 
     update_device_state("observingconditions", device_number, {"starfwhm": StarFWHM})
 
@@ -376,7 +374,7 @@ def set_temperature(
     # raise AlpacaError(0x407, "Device is not connected")
 
     if Temperature < -50.0 or Temperature > 50.0:
-        raise AlpacaError(0x402, "Temperature must be between -50.0°C and 50.0°C")
+        raise AlpacaError(0x401, "Temperature must be between -50.0°C and 50.0°C")
 
     update_device_state("observingconditions", device_number, {"temperature": Temperature})
 
@@ -410,7 +408,7 @@ def set_winddirection(
     # raise AlpacaError(0x407, "Device is not connected")
 
     if WindDirection < 0.0 or WindDirection >= 360.0:
-        raise AlpacaError(0x402, "Wind direction must be between 0.0 and 359.9 degrees")
+        raise AlpacaError(0x401, "Wind direction must be between 0.0 and 359.9 degrees")
 
     update_device_state("observingconditions", device_number, {"winddirection": WindDirection})
 
@@ -444,7 +442,7 @@ def set_windgust(
     # raise AlpacaError(0x407, "Device is not connected")
 
     if WindGust < 0.0 or WindGust > 150.0:
-        raise AlpacaError(0x402, "Wind gust must be between 0.0 and 150.0 m/s")
+        raise AlpacaError(0x401, "Wind gust must be between 0.0 and 150.0 m/s")
 
     update_device_state("observingconditions", device_number, {"windgust": WindGust})
 
@@ -478,7 +476,7 @@ def set_windspeed(
     # raise AlpacaError(0x407, "Device is not connected")
 
     if WindSpeed < 0.0 or WindSpeed > 100.0:
-        raise AlpacaError(0x402, "Wind speed must be between 0.0 and 100.0 m/s")
+        raise AlpacaError(0x401, "Wind speed must be between 0.0 and 100.0 m/s")
 
     update_device_state("observingconditions", device_number, {"windspeed": WindSpeed})
 

--- a/src/alpaca_simulators/api/switch.py
+++ b/src/alpaca_simulators/api/switch.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import APIRouter, Form, Path, Query
 
 from alpaca_simulators.api.common import AlpacaError, validate_device
@@ -15,12 +17,41 @@ from alpaca_simulators.state import (
 router = APIRouter()
 
 
+def _switches(state: dict) -> dict:
+    """Return the configured switches dict (tolerates legacy ``maxswitch``)."""
+    return state.get("switches", {}) or {}
+
+
+def _switch_config(state: dict, switch_id: int) -> dict[str, Any]:
+    """Look up a switch's config by ID, tolerating int or str keys (PyYAML
+    typically loads ``0:`` as an int but quoted ``"0":`` as a string).
+
+    Raises InvalidValue (0x401) if the ID is unknown.
+    """
+    switches = _switches(state)
+    if switch_id in switches:
+        return switches[switch_id]
+    if str(switch_id) in switches:
+        return switches[str(switch_id)]
+    raise AlpacaError(0x401, f"Invalid switch ID: {switch_id}")
+
+
+def _store_switch_value(device_number: int, state: dict, switch_id: int, value):
+    """Write back a switch value, preserving the existing key type."""
+    switches = _switches(state)
+    key = switch_id if switch_id in switches else str(switch_id)
+    switches[key]["value"] = value
+    update_device_state("switch", device_number, {"switches": switches})
+
+
 @router.get("/switch/{device_number}/maxswitch", response_model=IntResponse)
 def get_maxswitch(device_number: int = Path(..., ge=0), ClientTransactionID: int = Query(0)):
     validate_device("switch", device_number)
     state = get_device_state("switch", device_number)
+    # MaxSwitch is the count of configured switches; deriving it here keeps it
+    # consistent with which IDs the other endpoints will accept.
     return IntResponse(
-        Value=state.get("maxswitch", 0),
+        Value=len(_switches(state)),
         ClientTransactionID=ClientTransactionID,
         ServerTransactionID=get_server_transaction_id(),
     )
@@ -34,12 +65,7 @@ def get_canasync(
 ):
     validate_device("switch", device_number)
     state = get_device_state("switch", device_number)
-    switches = state.get("switches", {})
-
-    if str(Id) not in switches:
-        raise AlpacaError(0x402, f"Invalid switch ID: {Id}")
-
-    switch_config = switches[str(Id)]
+    switch_config = _switch_config(state, Id)
     return BoolResponse(
         Value=switch_config.get("canasync", False),
         ClientTransactionID=ClientTransactionID,
@@ -55,12 +81,7 @@ def get_canwrite(
 ):
     validate_device("switch", device_number)
     state = get_device_state("switch", device_number)
-    switches = state.get("switches", {})
-
-    if str(Id) not in switches:
-        raise AlpacaError(0x402, f"Invalid switch ID: {Id}")
-
-    switch_config = switches[str(Id)]
+    switch_config = _switch_config(state, Id)
     return BoolResponse(
         Value=switch_config.get("canwrite", True),
         ClientTransactionID=ClientTransactionID,
@@ -76,22 +97,9 @@ def get_getswitch(
 ):
     validate_device("switch", device_number)
     state = get_device_state("switch", device_number)
-    state = get_device_state("switch", device_number)
-    switches = state.get("switches", {})
-
-    if str(Id) not in switches:
-        raise AlpacaError(0x402, f"Invalid switch ID: {Id}")
-
-    # Get current value from state or default from config
-    switch_configs = state.get("switches", {})
-    if str(Id) in switch_configs:
-        value = switch_configs[str(Id)].get("value", False)
-    else:
-        value = switches[str(Id)].get("value", False)
-
-    # Convert to boolean
+    switch_config = _switch_config(state, Id)
+    value = switch_config.get("value", False)
     bool_value = bool(value) if isinstance(value, int | float) else value
-
     return BoolResponse(
         Value=bool_value,
         ClientTransactionID=ClientTransactionID,
@@ -107,12 +115,7 @@ def get_getswitchdescription(
 ):
     validate_device("switch", device_number)
     state = get_device_state("switch", device_number)
-    switches = state.get("switches", {})
-
-    if str(Id) not in switches:
-        raise AlpacaError(0x402, f"Invalid switch ID: {Id}")
-
-    switch_config = switches[str(Id)]
+    switch_config = _switch_config(state, Id)
     return StringResponse(
         Value=switch_config.get("description", ""),
         ClientTransactionID=ClientTransactionID,
@@ -128,12 +131,7 @@ def get_getswitchname(
 ):
     validate_device("switch", device_number)
     state = get_device_state("switch", device_number)
-    switches = state.get("switches", {})
-
-    if str(Id) not in switches:
-        raise AlpacaError(0x402, f"Invalid switch ID: {Id}")
-
-    switch_config = switches[str(Id)]
+    switch_config = _switch_config(state, Id)
     return StringResponse(
         Value=switch_config.get("name", f"Switch {Id}"),
         ClientTransactionID=ClientTransactionID,
@@ -149,21 +147,9 @@ def get_getswitchvalue(
 ):
     validate_device("switch", device_number)
     state = get_device_state("switch", device_number)
-    state = get_device_state("switch", device_number)
-    switches = state.get("switches", {})
-
-    if str(Id) not in switches:
-        raise AlpacaError(0x402, f"Invalid switch ID: {Id}")
-
-    # Get current value from state or default from config
-    switch_configs = state.get("switches", {})
-    if str(Id) in switch_configs:
-        value = switch_configs[str(Id)].get("value", 0.0)
-    else:
-        value = switches[str(Id)].get("value", 0.0)
-
+    switch_config = _switch_config(state, Id)
     return DoubleResponse(
-        Value=float(value),
+        Value=float(switch_config.get("value", 0.0)),
         ClientTransactionID=ClientTransactionID,
         ServerTransactionID=get_server_transaction_id(),
     )
@@ -177,12 +163,7 @@ def get_minswitchvalue(
 ):
     validate_device("switch", device_number)
     state = get_device_state("switch", device_number)
-    switches = state.get("switches", {})
-
-    if str(Id) not in switches:
-        raise AlpacaError(0x402, f"Invalid switch ID: {Id}")
-
-    switch_config = switches[str(Id)]
+    switch_config = _switch_config(state, Id)
     return DoubleResponse(
         Value=switch_config.get("minimum", 0.0),
         ClientTransactionID=ClientTransactionID,
@@ -198,12 +179,7 @@ def get_maxswitchvalue(
 ):
     validate_device("switch", device_number)
     state = get_device_state("switch", device_number)
-    switches = state.get("switches", {})
-
-    if str(Id) not in switches:
-        raise AlpacaError(0x402, f"Invalid switch ID: {Id}")
-
-    switch_config = switches[str(Id)]
+    switch_config = _switch_config(state, Id)
     return DoubleResponse(
         Value=switch_config.get("maximum", 1.0),
         ClientTransactionID=ClientTransactionID,
@@ -219,12 +195,7 @@ def get_switchstep(
 ):
     validate_device("switch", device_number)
     state = get_device_state("switch", device_number)
-    switches = state.get("switches", {})
-
-    if str(Id) not in switches:
-        raise AlpacaError(0x402, f"Invalid switch ID: {Id}")
-
-    switch_config = switches[str(Id)]
+    switch_config = _switch_config(state, Id)
     return DoubleResponse(
         Value=switch_config.get("step", 1.0),
         ClientTransactionID=ClientTransactionID,
@@ -239,7 +210,10 @@ def get_statechangecomplete(
     ClientTransactionID: int = Query(0),
 ):
     validate_device("switch", device_number)
-    # For simulator, state changes are always complete
+    state = get_device_state("switch", device_number)
+    # Validate the ID even though the result is fixed, so callers get a proper
+    # InvalidValue for unknown switches.
+    _switch_config(state, Id)
     return BoolResponse(
         Value=True,
         ClientTransactionID=ClientTransactionID,
@@ -256,26 +230,12 @@ def set_setswitch(
 ):
     validate_device("switch", device_number)
     state = get_device_state("switch", device_number)
-    state = get_device_state("switch", device_number)
+    switch_config = _switch_config(state, Id)
 
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
-
-    switches = state.get("switches", {})
-    if str(Id) not in switches:
-        raise AlpacaError(0x402, f"Invalid switch ID: {Id}")
-
-    switch_config = switches[str(Id)]
     if not switch_config.get("canwrite", True):
-        raise AlpacaError(0x401, f"Switch {Id} is read-only")
+        raise AlpacaError(0x400, f"Switch {Id} is read-only")
 
-    # Update switch state
-    switch_configs = state.get("switches", {})
-    if str(Id) not in switch_configs:
-        switch_configs[str(Id)] = {}
-
-    switch_configs[str(Id)]["value"] = State
-    update_device_state("switch", device_number, {"switches": switch_configs})
+    _store_switch_value(device_number, state, Id, State)
 
     return AlpacaResponse(
         ClientTransactionID=ClientTransactionID,
@@ -292,32 +252,17 @@ def set_setswitchvalue(
 ):
     validate_device("switch", device_number)
     state = get_device_state("switch", device_number)
-    state = get_device_state("switch", device_number)
+    switch_config = _switch_config(state, Id)
 
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
-
-    switches = state.get("switches", {})
-    if str(Id) not in switches:
-        raise AlpacaError(0x402, f"Invalid switch ID: {Id}")
-
-    switch_config = switches[str(Id)]
     if not switch_config.get("canwrite", True):
-        raise AlpacaError(0x401, f"Switch {Id} is read-only")
+        raise AlpacaError(0x400, f"Switch {Id} is read-only")
 
-    # Validate range
     min_val = switch_config.get("minimum", 0.0)
     max_val = switch_config.get("maximum", 1.0)
     if Value < min_val or Value > max_val:
-        raise AlpacaError(0x402, f"Value {Value} out of range ({min_val}-{max_val})")
+        raise AlpacaError(0x401, f"Value {Value} out of range ({min_val}-{max_val})")
 
-    # Update switch state
-    switch_configs = state.get("switches", {})
-    if str(Id) not in switch_configs:
-        switch_configs[str(Id)] = {}
-
-    switch_configs[str(Id)]["value"] = Value
-    update_device_state("switch", device_number, {"switches": switch_configs})
+    _store_switch_value(device_number, state, Id, Value)
 
     return AlpacaResponse(
         ClientTransactionID=ClientTransactionID,
@@ -333,19 +278,9 @@ def set_setswitchname(
     ClientTransactionID: int = Form(0),
 ):
     validate_device("switch", device_number)
-    # state = get_device_state("switch", device_number)
     state = get_device_state("switch", device_number)
-
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
-
-    switches = state.get("switches", {})
-    if str(Id) not in switches:
-        raise AlpacaError(0x402, f"Invalid switch ID: {Id}")
-
-    # For simulator, we'll just acknowledge the name change
-    # In a real implementation, this might update persistent configuration
-
+    _switch_config(state, Id)
+    # For simulator we acknowledge but don't persist name changes.
     return AlpacaResponse(
         ClientTransactionID=ClientTransactionID,
         ServerTransactionID=get_server_transaction_id(),
@@ -361,26 +296,12 @@ def set_setasync(
 ):
     validate_device("switch", device_number)
     state = get_device_state("switch", device_number)
-    state = get_device_state("switch", device_number)
+    switch_config = _switch_config(state, Id)
 
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
-
-    switches = state.get("switches", {})
-    if str(Id) not in switches:
-        raise AlpacaError(0x402, f"Invalid switch ID: {Id}")
-
-    switch_config = switches[str(Id)]
     if not switch_config.get("canasync", False):
-        raise AlpacaError(0x401, f"Switch {Id} does not support async operation")
+        raise AlpacaError(0x400, f"Switch {Id} does not support async operation")
 
-    # For simulator, treat same as synchronous
-    switch_configs = state.get("switches", {})
-    if str(Id) not in switch_configs:
-        switch_configs[str(Id)] = {}
-
-    switch_configs[str(Id)]["value"] = State
-    update_device_state("switch", device_number, {"switches": switch_configs})
+    _store_switch_value(device_number, state, Id, State)
 
     return AlpacaResponse(
         ClientTransactionID=ClientTransactionID,
@@ -397,32 +318,17 @@ def set_setasyncvalue(
 ):
     validate_device("switch", device_number)
     state = get_device_state("switch", device_number)
-    state = get_device_state("switch", device_number)
+    switch_config = _switch_config(state, Id)
 
-    # if not state.get("connected"):
-    # raise AlpacaError(0x407, "Device is not connected")
-
-    switches = state.get("switches", {})
-    if str(Id) not in switches:
-        raise AlpacaError(0x402, f"Invalid switch ID: {Id}")
-
-    switch_config = switches[str(Id)]
     if not switch_config.get("canasync", False):
-        raise AlpacaError(0x401, f"Switch {Id} does not support async operation")
+        raise AlpacaError(0x400, f"Switch {Id} does not support async operation")
 
-    # Validate range
     min_val = switch_config.get("minimum", 0.0)
     max_val = switch_config.get("maximum", 1.0)
     if Value < min_val or Value > max_val:
-        raise AlpacaError(0x402, f"Value {Value} out of range ({min_val}-{max_val})")
+        raise AlpacaError(0x401, f"Value {Value} out of range ({min_val}-{max_val})")
 
-    # For simulator, treat same as synchronous
-    switch_configs = state.get("switches", {})
-    if str(Id) not in switch_configs:
-        switch_configs[str(Id)] = {}
-
-    switch_configs[str(Id)]["value"] = Value
-    update_device_state("switch", device_number, {"switches": switch_configs})
+    _store_switch_value(device_number, state, Id, Value)
 
     return AlpacaResponse(
         ClientTransactionID=ClientTransactionID,

--- a/src/alpaca_simulators/config/template.yaml
+++ b/src/alpaca_simulators/config/template.yaml
@@ -28,8 +28,6 @@ devices:
       fastreadout: false
       fullwellcapacity: 50000
       gain: 1
-      gainmax: 10
-      gainmin: 1
       gains: ["High", "Medium", "Low"]
       hasshutter: true
       heatsinktemperature: 25.0
@@ -43,11 +41,8 @@ devices:
       readoutmodes: ["Fast", "Normal", "High Quality"]
       sensorname: "Sony ICX694"
       sensortype: 1  # Monochrome
-      offset: 100
-      offsetmax: 1000
-      offsetmin: 0
+      offset: 1
       offsets: ["Low", "Medium", "High"]
-      subexposureduration: 0.0
       bayeroffsetx: 0
       bayeroffsety: 0
       binx: 1


### PR DESCRIPTION
This pull request makes several important improvements and corrections to the camera API simulator, focusing on stricter validation, improved error handling, and better adherence to the ASCOM standard for gain/offset and sub-exposure controls. The changes also refactor some behaviors to more accurately simulate real hardware, particularly for subframe validation and pulse guiding.

Key changes include:

### Validation and Error Handling Improvements

* Subframe geometry (NumX/NumY/StartX/StartY) is now strictly validated in `start_exposure`, ensuring that binned subframes are within camera bounds. Setters for these values now only reject obviously invalid input, while full validation is deferred to exposure start. [[1]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eL296-R343) [[2]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eL1050-R1079) [[3]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eL1089-R1110) [[4]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eL1127-R1140) [[5]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eL1165-R1170)
* Error codes have been updated throughout to better match ASCOM conventions, and several endpoints now raise `PropertyNotImplemented` errors when a feature is not supported (e.g., sub-exposure duration, gain/offset min/max). [[1]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eL828-R877) [[2]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eL925-R980) [[3]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eL997-R1039) [[4]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eR1285-R1292) [[5]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eL1311-R1302)

### Gain and Offset List Mode Compliance

* The camera now operates in "list mode" for both gain and offset: values are integer indices into the respective lists, and min/max endpoints return `PropertyNotImplemented` as required by ASCOM. The API models and validation logic have been updated accordingly. [[1]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eL887-R944) [[2]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eL901-R961) [[3]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eL925-R980) [[4]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eL959-R1003) [[5]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eL973-R1020) [[6]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eL997-R1039)

### Pulse Guiding Simulation

* Pulse guiding is now simulated asynchronously: the `ispulseguiding` flag is held true for the requested duration, then cleared, more closely matching real hardware behavior.

### Miscellaneous Corrections

* Fast readout and CCD temperature endpoints now check capabilities and use correct error codes. [[1]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eR1185-R1186) [[2]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eL1204-R1204) [[3]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eL828-R877)
* Exposure duration endpoints now properly handle the case where no exposure has been taken. [[1]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eR738-R739) [[2]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eR753-R757)
* The image cache key now includes subframe and binning parameters for better cache accuracy. [[1]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eL32-R48) [[2]](diffhunk://#diff-a05c177ab0539b7c21993b3752e6bc2f86ac60befea85d1320d8968b0d10f01eR191-R194)